### PR TITLE
Major Feature: removal of `-q` option, implementation of positional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ Decision-making made easy. Ask a question to get back a yes or no answer.
 
 ```sh
 USAGE
-  $ should-i
+  $ should-i QUESTION
+
+ARGUMENTS
+  QUESTION  the question you want answered
 
 OPTIONS
-  -h, --help               show CLI help
-  -q, --question=question  question to ask
-  -v, --version            show CLI version
+  -h, --help     show CLI help
+  -v, --version  show CLI version
 
 DESCRIPTION
   Decision-making made easy. Ask a question to get back a yes or no answer.
@@ -28,13 +30,13 @@ DESCRIPTION
 `should-i` has your best interest in mind (most of the time).
 
 ```sh
-$ should-i -q "go for a run tonight?"
-✖ no
+$ should-i "go for a run tonight?"
+✖ no way, Jose
 ```
 
 ```sh
-$ should-i -q "eat whatever I feel like?"
-✔ yes
+$ should-i "eat whatever I feel like?"
+✔ totally
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "@oclif/command": "^1.4.30",
     "@oclif/config": "^1.6.18",
     "@oclif/plugin-help": "^1.2.11",
-    "axios": "^0.18.0",
-    "internet-available": "^1.0.0",
     "ora": "^2.1.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,18 +9,12 @@ const {api, yesno, noSayings, yesSayings} = require('../src/utils');
 class ShouldICliCommand extends Command {
   async run() {
     const {flags} = this.parse(ShouldICliCommand);
-    
     const {args} = this.parse(ShouldICliCommand);
 
-    // if no flags, display should-i usage message
-    if (Object.keys(flags).length === 0) {
-      await ShouldICliCommand.run(['--help'], flags.help);
-    }
-
-    // -q | --question - return yes or no phrase
+    // QUESTION positional argument
     //  - if connected to internet, make a request against https://yesno.wtf/api
     //  - if no connection, make a request against local yes/no generator
-    let question = flags.question;
+    let question = args.question;
     let answer;
 
     question = (question.endsWith('?')) ? question : question.concat('?');
@@ -60,10 +54,10 @@ Decision-making made easy. Ask a question to get back a yes or no answer.
 
 ShouldICliCommand.args = [
   {
-    name: 'question',                   // name of arg to show in help and reference with args[name]
-    required: true,                     // make the arg required with `required: true`
-    description: 'question to answer',  // help description
-  }
+    name: 'question',                               // name of arg to show in help and reference with args[name]
+    required: true,                                 // make the arg required with `required: true`
+    description: 'the question you want answered',  // help description
+  },
 ];
 
 ShouldICliCommand.flags = {
@@ -71,7 +65,6 @@ ShouldICliCommand.flags = {
   version: flags.version({char: 'v'}),
   // add --help flag to show CLI version
   help: flags.help({char: 'h'}),
-  question: flags.string({char: 'q', description: 'question to ask'}),
 };
 
 module.exports = ShouldICliCommand;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,8 @@ const {api, yesno, noSayings, yesSayings} = require('../src/utils');
 class ShouldICliCommand extends Command {
   async run() {
     const {flags} = this.parse(ShouldICliCommand);
+    
+    const {args} = this.parse(ShouldICliCommand);
 
     // if no flags, display should-i usage message
     if (Object.keys(flags).length === 0) {
@@ -55,6 +57,14 @@ class ShouldICliCommand extends Command {
 ShouldICliCommand.description = `
 Decision-making made easy. Ask a question to get back a yes or no answer.
 `;
+
+ShouldICliCommand.args = [
+  {
+    name: 'question',                   // name of arg to show in help and reference with args[name]
+    required: true,                     // make the arg required with `required: true`
+    description: 'question to answer',  // help description
+  }
+];
 
 ShouldICliCommand.flags = {
   // add --version flag to show CLI version

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,14 @@
 /* eslint-disable require-jsdoc */
 
 const ora = require('ora');
-const internetAvailable = require('internet-available');
-
 const {Command, flags} = require('@oclif/command');
-const {api, yesno, noSayings, yesSayings} = require('../src/utils');
+const {generateYesOrNo, noSayings, yesSayings} = require('../src/utils');
 
 class ShouldICliCommand extends Command {
   async run() {
-    const {flags} = this.parse(ShouldICliCommand);
     const {args} = this.parse(ShouldICliCommand);
-
+    const ANSWER_DELAY = 1000;
     // QUESTION positional argument
-    //  - if connected to internet, make a request against https://yesno.wtf/api
-    //  - if no connection, make a request against local yes/no generator
     let question = args.question;
     let answer;
 
@@ -22,21 +17,14 @@ class ShouldICliCommand extends Command {
 
     const spinner = ora(fullQuestion).start();
 
-    try { // user is online, has internet connection
-      await internetAvailable({
-        timeout: 2000,
-        retries: 3,
-      });
-      answer = (await api(fullQuestion)).answer;
-    } catch (err) { // user is offline, does not have internet connection
-      answer = (await yesno(fullQuestion));
-    }
-
-    if (answer === 'yes') {
-      spinner.succeed(this.getRandomSaying(answer));
-    } else {
-      spinner.fail(this.getRandomSaying(answer));
-    }
+    answer = generateYesOrNo(fullQuestion);
+    setTimeout(() => {
+      if (answer === 'yes') {
+        spinner.succeed(this.getRandomSaying(answer));
+      } else {
+        spinner.fail(this.getRandomSaying(answer));
+      }
+    }, ANSWER_DELAY);
   };
 
   getRandomSaying(answer) {
@@ -54,9 +42,9 @@ Decision-making made easy. Ask a question to get back a yes or no answer.
 
 ShouldICliCommand.args = [
   {
-    name: 'question',                               // name of arg to show in help and reference with args[name]
-    required: true,                                 // make the arg required with `required: true`
-    description: 'the question you want answered',  // help description
+    name: 'question',
+    required: true,
+    description: 'the question you want answered',
   },
 ];
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,3 @@
-const axios = require('axios');
-
 // List of words / phrases that should be given "no" answers every time.
 // Implemented by @alqahtani, pull request #2
 const absolutelyNo = (text) => {
@@ -19,20 +17,7 @@ const forbiddenWords = [
 ];
 // End of forbidden words feature
 
-exports.api = async (fullQuestion) => {
-  if (this.absolutelyNo(fullQuestion)) {
-    return 'no';
-  }
-  const requestConfig = {
-    headers: {'Content-Type': 'application/json'},
-    baseURL: 'https://yesno.wtf/api/',
-    method: 'get',
-  };
-  const results = await axios(requestConfig);
-  return results.data;
-};
-
-exports.yesno = (fullQuestion) => {
+exports.generateYesOrNo = (fullQuestion) => {
   if (absolutelyNo(fullQuestion)) {
     return 'no';
   }


### PR DESCRIPTION
Per a reddit comment:

> But OK, one advice: even for such simple learning projects, think about design and user interface in first place. For example, why do you even need -q key? Would make more sense if it take a question directly with should-i "question here". -h and -v are fine. And you can go even more! Since it doesn't take any other positional arguments, only one, you can even not require quotes, like commands like echo do. Just should-i learn more about user interface. Compare it with that monstrous should-i -q "learn more about user interface" from position of user that will use it often (let's imagine somebody will).

I totally agreed and would have liked to have it this way from the start, but its never too late to make changes with your own projects! This PR makes it so that the option flag `-q | --question` is removed and the old / previous:

```
$ should-i -q "go for a run tonight?"
✖ negative
```
can now be written as a simpler:

```
$ should-i "go for a run tonight?"
✔ surely
```

Before accepting this PR, I'd like to see if I can get it so that even the quotes around the question are not necessary (similar to `echo`), essentially having *n* number of positional arguments rather than one defined *question* arg which requires quotation marks.